### PR TITLE
fix: bound environment alert click with 15s timeout to prevent CI hang

### DIFF
--- a/src/services/lottoService.core.ts
+++ b/src/services/lottoService.core.ts
@@ -145,10 +145,17 @@ export class LottoServiceCore implements LottoServiceInterface {
     const page = await this.browserController.focus(0);
     await page.goto(URLS.LOTTO_645);
 
-    // remove alert in linux env (비정상적인 방법으로 접속)
+    // remove alert in CI env (비정상적인 방법으로 접속)
+    // 팝업 마크업은 항상 DOM에 존재하지만 노출 여부는 환경에 따라 다르므로,
+    // 15초 안에 표시되지 않으면 없는 것으로 간주하고 진행한다.
     if (process.env.CI) {
-      this.logger.debug('[purchase]', 'click environment alert confirm');
-      await page.click(SELECTORS.ENVIRONMENT_ALERT_CONFIRM);
+      try {
+        await page.waitForSelector(SELECTORS.ENVIRONMENT_ALERT_CONFIRM, 15000);
+        this.logger.debug('[purchase]', 'click environment alert confirm');
+        await page.click(SELECTORS.ENVIRONMENT_ALERT_CONFIRM);
+      } catch {
+        this.logger.debug('[purchase]', 'environment alert not shown within 15s, skip');
+      }
     }
 
     // click auto button


### PR DESCRIPTION
## Problem

Since ~2026-07-11, every purchase run in CI hangs at `click environment alert confirm` until the 6h GitHub Actions job limit kills it (see bang9/lotto-purchase cron runs on 7/12, 7/13, 7/20 — all cancelled at exactly +6h).

Root cause:
- Under `process.env.CI`, `purchase()` unconditionally clicks the "비정상적인 방법으로 접속" alert confirm button.
- The playwright controller clicks with `{ timeout: 0 }` (infinite wait for actionability).
- The popup markup is always present in the DOM but hidden; dhlottery stopped showing it in CI environments between 7/6 and 7/11, so the click waits forever for it to become visible.

## Fix

Wait up to **15s** for the alert confirm button to become visible (`waitForSelector`, part of the existing `BrowserPageInterface`). If it doesn't show, log and skip — the popup is optional; the purchase flow continues either way.

Works across controllers: playwright waits for visibility, puppeteer/webview failures are caught and skipped the same way.

## Verification

- `pnpm lint` / `pnpm build` pass.
- `lottoService.test.ts` failures are pre-existing (E2E tests requiring `LOTTO_ID`/`LOTTO_PWD` env); identical failures on unmodified main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)